### PR TITLE
#13 エラー時の画像が消えない対策

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 .byebug_history
 
 /vendor/bundle/
+/public/uploads/

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -33,6 +33,6 @@ class PostsController < ApplicationController
 
   private
     def post_params
-      params.require(:post).permit(:title, :content, :postimage)
+      params.require(:post).permit(:title, :content, :postimage, :postimage_cache)
     end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,9 +3,15 @@ class Post < ApplicationRecord
   has_many :comments, dependent: :destroy
   mount_uploader :postimage, PostimageUploader
 
+  # draft(0): 下書き
+  # published(1) : 通常状態
+  # archived(-1) : 一覧に表示されなくなる（アーカイブ）
+  enum status: {draft:0, published:1, archived:-1 }
 
   validates :title,  presence: true
   validates :content, presence: true
+  validates :status, presence: true, inclusion: {in: Post.statuses.keys}
+
   # postimage の validation(size) は uploaders/postimage_uploader.rb
     # def size_range
     #   1..5.megabytes

--- a/app/uploaders/postimage_uploader.rb
+++ b/app/uploaders/postimage_uploader.rb
@@ -37,6 +37,10 @@ class PostimageUploader < CarrierWave::Uploader::Base
     process resize_to_fill: [150, 150]
   end
 
+  # validation error時の再表示する時の画像サイズ
+  version :thumb_error do
+    process resize_to_fill: [75, 75]
+  end
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_whitelist

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,10 +1,13 @@
 <h1>投稿一覧表示</h1><br><hr>
 <% @post.each do |post| %>
-  <h2><%= link_to post.title, post_path(post.id)  %></h2>
-  <p>本文　：　<%= post.content%></p>
-  <p><%= post.created_at.strftime('%Y-%m-%d %H:%M:%S') %></p>
-  <p><%= image_tag(post.postimage.thumb.url) if post.postimage?%></p>
-  <p><em>ユーザー名：<%= post.user.username %> </em></p>
-  <p><%= time_ago_in_words(post.created_at)%></p>
-  <br><hr>
+<!-- published の記事のみ表示 published(公開) -->
+  <% if post.published? %>
+    <h2><%= link_to post.title, post_path(post.id)  %></h2>
+    <p>本文　：　<%= post.content%></p>
+    <p><%= post.created_at.strftime('%Y-%m-%d %H:%M:%S') %></p>
+    <p><%= image_tag(post.postimage.thumb.url) if post.postimage?%></p>
+    <p><em>ユーザー名：<%= post.user.username %> </em></p>
+    <p><%= time_ago_in_words(post.created_at)%></p>
+    <br><hr>
+  <% end %>
 <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -14,7 +14,9 @@
 
   <div class="field">
     <%= f.label :postimage %><br />
+    <%= image_tag(@post.postimage.thumb_error.url) if @post.postimage? %>
     <%= f.file_field :postimage %>
+    <%= f.hidden_field :postimage_cache %>
   </div><br />
 
   <div class="actions">

--- a/db/migrate/20180220154743_add_status_to_posts.rb
+++ b/db/migrate/20180220154743_add_status_to_posts.rb
@@ -1,0 +1,5 @@
+class AddStatusToPosts < ActiveRecord::Migration[5.1]
+  def change
+    add_column :posts, :status, :integer ,default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180214182647) do
+ActiveRecord::Schema.define(version: 20180220154743) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20180214182647) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "postimage"
+    t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
closed #13 
画像を含んだ投稿時にバリデーションエラーが発生すると、再表示時に画像が消えてしまっていたのをそのまま投稿ができるように変更。